### PR TITLE
Fix shade configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,9 +144,9 @@
                             </transformers>
                             <artifactSet>
                                 <excludes>
-                                    <exclude>javax.servlet:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>org.eclipse.jetty:*</exclude>
+                                    <exclude>javax.servlet:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -139,10 +139,16 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>javax.servlet:*</exclude>
+                                    <exclude>org.slf4j:*</exclude>
+                                    <exclude>org.eclipse.jetty:*</exclude>
+                                </excludes>
+                            </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache</pattern>


### PR DESCRIPTION
slf4j 和 jetty 相关的依赖，被原样 shade 进去了，如果使用者引入了 slf4j 和 jetty 依赖，就会导致类冲突，使用者无法排除被 shade 进去的类。
所以这些没改包名就 shade 进去的类，应该释放回间接依赖里，让使用者如果遇到版本冲突，可以自行选择版本。